### PR TITLE
updated ds.js file

### DIFF
--- a/ds.js
+++ b/ds.js
@@ -153,8 +153,10 @@ function infixToPostfix(expression, tab = 0) {
     } else if (isAnOperator(char)) {
       let pref = preference[char];
       let peek = stack[stack.length - 1];
-
-      while (pref < preference[peek]) {
+      if(char=='^')
+         stack.push('^');
+      else{
+      while (pref <= preference[peek]) {
         if (peek === "(") {
           break;
         }
@@ -163,7 +165,8 @@ function infixToPostfix(expression, tab = 0) {
         peek = stack[stack.length - 1];
       }
       stack.push(char);
-    }
+      }
+  }
     if (tab == 1) {
       table.exp.push(char);
       table.stack.push(stack.join(" "));


### PR DESCRIPTION
The current version pops from the stack only when the element has lower precedence that the operator in the top of the stack..  But actually, the popping should be done even when the element in the top of the stack has the same priority (except for '^' operator as it has same priority.  References: 
GFG: https://www.geeksforgeeks.org/convert-infix-expression-to-postfix-expression/ Quescol: https://quescol.com/data-structure/infix-to-postfix  This issue has been fixed in the ds.js file and the same algorithmic change has been documented in the prefixAndPostfixConvertor.html file.