### PR TITLE
update prefix and postfixconvertor.html

### DIFF
--- a/prefixAndPostfixConvertor.html
+++ b/prefixAndPostfixConvertor.html
@@ -128,9 +128,9 @@
                                             postfix expression
                                         </li>
                                         <li>IF an operator O is encountered, then <br>
-                                            a. Repeatedly pop from stack and add each operator ( popped from the stack)
-                                            to the postfix expression which has the higher precedence
-                                            than O
+                                            a. If the operator O is '^' go directly to step b, else repeatedly pop from stack and add each operator ( popped from the stack)
+                                            to the postfix expression which has the higher or equal precedence
+                                            than O.
                                             <br>b. Push the operator O to the stack.
                                         </li>
                                     </ul>


### PR DESCRIPTION
The current version pops from the stack only when the element has lower precedence that the operator in the top of the stack..  But actually, the popping should be done even when the element in the top of the stack has the same priority (except for '^' operator as it has same priority.  References: 
GFG: https://www.geeksforgeeks.org/convert-infix-expression-to-postfix-expression/ Quescol: https://quescol.com/data-structure/infix-to-postfix  This issue has been fixed in the ds.js file and the same algorithmic change has been documented in the prefixAndPostfixConvertor.html file.